### PR TITLE
Dark Mode Support

### DIFF
--- a/Fuel/AddStopViewController.swift
+++ b/Fuel/AddStopViewController.swift
@@ -22,6 +22,7 @@ class AddStopViewController: UIViewController, AddStopContractView {
     private let pricePerGallonTextField: UITextField = {
         let label = UITextField()
         label.font = UIFont.systemFont(ofSize: 30.0)
+        label.textColor = UIColor.label
         label.textAlignment = .center
         label.placeholder = "$0.00"
         label.keyboardType = .decimalPad
@@ -32,6 +33,7 @@ class AddStopViewController: UIViewController, AddStopContractView {
     private let gallonsTextField: UITextField = {
         let label = UITextField()
         label.font = UIFont.systemFont(ofSize: 30.0)
+        label.textColor = UIColor.label
         label.textAlignment = .center
         label.placeholder = "0.0000"
         label.keyboardType = .decimalPad
@@ -42,6 +44,7 @@ class AddStopViewController: UIViewController, AddStopContractView {
     private let costTextField: UITextField = {
         let label = UITextField()
         label.font = UIFont.systemFont(ofSize: 30.0)
+        label.textColor = UIColor.label
         label.textAlignment = .center
         label.placeholder = "$0.00"
         label.keyboardType = .decimalPad
@@ -52,6 +55,7 @@ class AddStopViewController: UIViewController, AddStopContractView {
     private let tripOdometerTextField: UITextField = {
         let label = UITextField()
         label.font = UIFont.systemFont(ofSize: 30.0)
+        label.textColor = UIColor.label
         label.textAlignment = .center
         label.placeholder = "0000"
         label.keyboardType = .decimalPad
@@ -62,6 +66,7 @@ class AddStopViewController: UIViewController, AddStopContractView {
     private let tripMPGTextField: UITextField = {
         let label = UITextField()
         label.font = UIFont.systemFont(ofSize: 30.0)
+        label.textColor = UIColor.label
         label.textAlignment = .center
         label.placeholder = "00.000"
         label.keyboardType = .decimalPad
@@ -72,6 +77,7 @@ class AddStopViewController: UIViewController, AddStopContractView {
     private let odometerTextField: UITextField = {
         let label = UITextField()
         label.font = UIFont.systemFont(ofSize: 30.0)
+        label.textColor = UIColor.label
         label.textAlignment = .center
         label.placeholder = "00000"
         label.keyboardType = .numberPad
@@ -82,6 +88,7 @@ class AddStopViewController: UIViewController, AddStopContractView {
     private let octaneTextField: UITextField = {
         let label = UITextField()
         label.font = UIFont.systemFont(ofSize: 30.0)
+        label.textColor = UIColor.label
         label.textAlignment = .center
         label.placeholder = "00"
         label.keyboardType = .numberPad
@@ -148,7 +155,7 @@ class AddStopViewController: UIViewController, AddStopContractView {
     
     // MARK: - View Hierarchy Setup
     private func setupViewHierarchy() {
-        view.backgroundColor = UIColor(red: 242.0 / 255.0, green: 243.0 / 255.0, blue: 246.0 / 255.0, alpha: 1.0)
+        view.backgroundColor = UIColor.systemGray6
                 
         let topStack = UIStackView()
         topStack.axis = .horizontal
@@ -188,18 +195,16 @@ class AddStopViewController: UIViewController, AddStopContractView {
         
         view.addSubview(bottomStack)
 
-        let blue = UIColor(red: 0.0, green: 120.0 / 255.0, blue: 1.0, alpha: 1.0)
         let saveButton = UIButton()
         saveButton.setTitle("Save", for: .normal)
-        saveButton.setTitleColor(blue, for: .normal)
-        saveButton.titleLabel?.font = UIFont.systemFont(ofSize: 15.0, weight: .bold)
+        saveButton.setTitleColor(UIColor.systemBlue, for: .normal)
+        saveButton.titleLabel?.font = UIFont.systemFont(ofSize: 17.0, weight: .bold)
         saveButton.addTarget(self, action: #selector(handleSaveTap(_:)), for: .touchUpInside)
         
         let cancelButton = UIButton()
         cancelButton.setTitle("Cancel", for: .normal)
-        cancelButton.setTitleColor(blue, for: .normal)
-        cancelButton.titleLabel?.font = UIFont.systemFont(ofSize: 15.0, weight: .bold)
-        cancelButton.titleLabel?.textColor = UIColor(red: 0.0, green: 120.0 / 255.0, blue: 1.0, alpha: 1.0)
+        cancelButton.setTitleColor(UIColor.systemBlue, for: .normal)
+        cancelButton.titleLabel?.font = UIFont.systemFont(ofSize: 17.0, weight: .bold)
         cancelButton.addTarget(self, action: #selector(handleCancelTap(_:)), for: .touchUpInside)
         
         let buttonStack = UIStackView()
@@ -242,6 +247,7 @@ class AddStopViewController: UIViewController, AddStopContractView {
     private func createDescriptionLabel(text: String) -> UILabel {
         let label = UILabel()
         label.font = UIFont.systemFont(ofSize: 17.0)
+        label.textColor = UIColor.label
         label.text = text
         label.textAlignment = .center
         label.translatesAutoresizingMaskIntoConstraints = false

--- a/Fuel/OverviewStopTableCell.swift
+++ b/Fuel/OverviewStopTableCell.swift
@@ -20,6 +20,7 @@ class OverviewStopTableCell: UITableViewCell {
     let stopDate: UILabel = {
         let label = UILabel()
         label.font = UIFont.systemFont(ofSize: 17.0, weight: .bold)
+        label.textColor = UIColor.label
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
@@ -27,6 +28,7 @@ class OverviewStopTableCell: UITableViewCell {
     let gallonsFilled: UILabel = {
         let label = UILabel()
         label.font = UIFont.systemFont(ofSize: 17.0)
+        label.textColor = UIColor.label
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
@@ -35,6 +37,7 @@ class OverviewStopTableCell: UITableViewCell {
         let label = UILabel()
         label.text = "gallons"
         label.font = UIFont.systemFont(ofSize: 17.0)
+        label.textColor = UIColor.label
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
@@ -42,6 +45,7 @@ class OverviewStopTableCell: UITableViewCell {
     let totalPrice: UILabel = {
         let label = UILabel()
         label.font = UIFont.systemFont(ofSize: 25.0)
+        label.textColor = UIColor.label
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
@@ -57,10 +61,8 @@ class OverviewStopTableCell: UITableViewCell {
     }
     
     private func commonSetup() {
-        let gray = UIColor(red: 242.0 / 255.0, green: 243.0 / 255.0, blue: 246.0 / 255.0, alpha: 1.0)
-        backgroundColor = gray
         let backgroundView = UIView()
-        backgroundView.backgroundColor = gray
+        backgroundView.backgroundColor = UIColor.systemGray6
         selectedBackgroundView = backgroundView
         
         stageView.addSubview(stopDate)

--- a/Fuel/OverviewViewController.swift
+++ b/Fuel/OverviewViewController.swift
@@ -23,7 +23,7 @@ class OverviewViewController: UIViewController, OverviewContractView, MKMapViewD
         let table = UITableView()
         table.dataSource = self
         table.delegate = self
-        table.backgroundColor = UIColor(red: 242.0 / 255.0, green: 243.0 / 255.0, blue: 246.0 / 255.0, alpha: 1.0)
+        table.backgroundColor = UIColor.systemGray6
         table.separatorStyle = .none
         table.register(OverviewStopTableCell.self, forCellReuseIdentifier: "stopTableCell")
         return table

--- a/Fuel/StopDetailViewController.swift
+++ b/Fuel/StopDetailViewController.swift
@@ -15,6 +15,7 @@ class StopDetailViewController: UIViewController {
     private let stopDateLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.systemFont(ofSize: 17.0, weight: .bold)
+        label.textColor = UIColor.label
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
@@ -22,6 +23,7 @@ class StopDetailViewController: UIViewController {
     private let ppgLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.systemFont(ofSize: 30.0)
+        label.textColor = UIColor.label
         label.textAlignment = .center
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
@@ -30,6 +32,7 @@ class StopDetailViewController: UIViewController {
     private let gallonsLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.systemFont(ofSize: 30.0)
+        label.textColor = UIColor.label
         label.textAlignment = .center
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
@@ -38,6 +41,7 @@ class StopDetailViewController: UIViewController {
     private let costLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.systemFont(ofSize: 30.0)
+        label.textColor = UIColor.label
         label.textAlignment = .center
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
@@ -46,6 +50,7 @@ class StopDetailViewController: UIViewController {
     private let tripOdometerLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.systemFont(ofSize: 30.0)
+        label.textColor = UIColor.label
         label.textAlignment = .center
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
@@ -54,6 +59,7 @@ class StopDetailViewController: UIViewController {
     private let tripMPGLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.systemFont(ofSize: 30.0)
+        label.textColor = UIColor.label
         label.textAlignment = .center
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
@@ -62,6 +68,7 @@ class StopDetailViewController: UIViewController {
     private let odometerLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.systemFont(ofSize: 30.0)
+        label.textColor = UIColor.label
         label.textAlignment = .center
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
@@ -70,6 +77,7 @@ class StopDetailViewController: UIViewController {
     private let octaneLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.systemFont(ofSize: 30.0)
+        label.textColor = UIColor.label
         label.textAlignment = .center
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
@@ -172,6 +180,7 @@ class StopDetailViewController: UIViewController {
     private func createDescriptionLabel(text: String) -> UILabel {
         let label = UILabel()
         label.font = UIFont.systemFont(ofSize: 17.0)
+        label.textColor = UIColor.label
         label.text = text
         label.textAlignment = .center
         label.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
Refactor colors to use Apple [Standard Colors](https://developer.apple.com/documentation/uikit/uicolor/standard_colors) to gain automatic support for Dark Mode.

**Add Stop - Light Mode**

![Simulator Screen Shot - iPhone 12 Pro Max - 2021-03-11 at 21 16 31](https://user-images.githubusercontent.com/989928/110888294-81985b00-82b1-11eb-9725-67ccfc78b1b5.png)


**Add Stop - Dark Mode**

![Simulator Screen Shot - iPhone 12 Pro Max - 2021-03-11 at 21 17 02](https://user-images.githubusercontent.com/989928/110888307-852be200-82b1-11eb-8e29-b6694130e941.png)

